### PR TITLE
add logs and storage from `src/dagster_home` to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -166,3 +166,9 @@ cython_debug/
 # ignore everything inside the mongodb directory
 mongodb/**
 mongodb/**/*
+
+
+src/dagster_home/logs/**
+src/dagster_home/logs/**/*
+src/dagster_home/storage/**
+src/dagster_home/storage/**/*


### PR DESCRIPTION
## Enhancement
This PR adds the logs and storage directly from Dagster home to `.gitignore` 